### PR TITLE
[fix]最新のyarnをインストール

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,14 @@ COPY . /search-word-app
 ARG RAILS_MASTER_KEY
 ENV RAILS_MASTER_KEY ${RAILS_MASTER_KEY}
 
-# yarnのインストール確認
-RUN apt-get install -y yarn
+# Yarnの公式リポジトリを追加
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+# 更新して最新のyarnをインストール
+RUN apt-get update && apt-get install -y yarn
+
+# バージョンを確認
 RUN yarn --version
 
 RUN RAILS_ENV=production bundle exec rails assets:precompile


### PR DESCRIPTION
RUN yarn --versionの結果、0.32+gitと表示された。
0.32+gitは古いyarnのため最新のyarnをインストールする。