### PR TITLE
[fix] UglifierはES6の構文もサポートするようにする

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
assets:precompile時のJavaScriptの圧縮時にUglifierが使用される。
ここで、block_form.jsにはES6の構文が使用されているためエラーが生じたと思われる。

よってES6をサポートするように変更した。
